### PR TITLE
fix: memoize input components

### DIFF
--- a/src/components/CustomLinkInput.tsx
+++ b/src/components/CustomLinkInput.tsx
@@ -1,5 +1,5 @@
 import {Select, Spinner} from '@sanity/ui'
-import {useEffect, useState} from 'react'
+import {memo, useEffect, useState} from 'react'
 import {SanityDocument, set, type StringInputProps, useFormValue, useWorkspace} from 'sanity'
 import styled from 'styled-components'
 
@@ -13,7 +13,7 @@ const OptionsSpinner = styled(Spinner)`
  * Custom input component used for custom link types.
  * Renders a dropdown with the available options for the custom link type.
  */
-export function CustomLinkInput(
+export const CustomLinkInput = memo(function CustomLinkInput(
   props: StringInputProps & {
     customLinkTypes: CustomLinkType[]
   },
@@ -56,4 +56,4 @@ export function CustomLinkInput(
   ) : (
     <OptionsSpinner />
   )
-}
+})

--- a/src/components/LinkInput.tsx
+++ b/src/components/LinkInput.tsx
@@ -1,4 +1,5 @@
 import {Box, Flex, Stack, Text} from '@sanity/ui'
+import {memo} from 'react'
 import {type FieldMember, FormFieldValidationStatus, ObjectInputMember} from 'sanity'
 import styled from 'styled-components'
 
@@ -23,7 +24,7 @@ const FullWidthStack = styled(Stack)`
  *
  * The rest of the fields ("blank" and "advanced") are rendered as usual.
  */
-export function LinkInput(props: LinkInputProps) {
+export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
   const [textField, typeField, linkField, ...otherFields] = props.members as FieldMember[]
   const {options} = props.schemaType
 
@@ -138,4 +139,4 @@ export function LinkInput(props: LinkInputProps) {
       ))}
     </Stack>
   )
-}
+})

--- a/src/components/LinkTypeInput.tsx
+++ b/src/components/LinkTypeInput.tsx
@@ -5,6 +5,7 @@ import {set, type StringInputProps} from 'sanity'
 import styled from 'styled-components'
 
 import {CustomLinkType, LinkFieldPluginOptions, LinkType} from '../types'
+import {memo} from 'react'
 
 const defaultLinkTypes: LinkType[] = [
   {title: 'Internal', value: 'internal', icon: LinkIcon},
@@ -33,7 +34,7 @@ const LinkTypeMenuItem = styled(MenuItem)`
  * Custom input component for the "type" field on the link object.
  * Renders a button with an icon and a dropdown menu to select the link type.
  */
-export function LinkTypeInput({
+export const LinkTypeInput = memo(function LinkTypeInput({
   value,
   onChange,
   customLinkTypes = [],
@@ -81,4 +82,4 @@ export function LinkTypeInput({
       }
     />
   )
-}
+})

--- a/src/linkField.tsx
+++ b/src/linkField.tsx
@@ -92,7 +92,13 @@ export const linkField = definePlugin<LinkFieldPluginOptions | void>((opts) => {
         initialValue: 'internal',
         validation: (Rule) => Rule.required(),
         components: {
-          input: (props) => LinkTypeInput({customLinkTypes, linkableSchemaTypes, ...props}),
+          input: (props) => (
+            <LinkTypeInput
+              customLinkTypes={customLinkTypes}
+              linkableSchemaTypes={linkableSchemaTypes}
+              {...props}
+            />
+          ),
         },
       }),
 
@@ -162,7 +168,7 @@ export const linkField = definePlugin<LinkFieldPluginOptions | void>((opts) => {
         description: descriptions?.external,
         hidden: ({parent}) => !parent || !isCustomLink(parent as LinkValue),
         components: {
-          input: (props) => CustomLinkInput({customLinkTypes, ...props}),
+          input: (props) => <CustomLinkInput customLinkTypes={customLinkTypes} {...props} />,
         },
       }),
 
@@ -257,8 +263,9 @@ export const linkField = definePlugin<LinkFieldPluginOptions | void>((opts) => {
         : []),
     ],
     components: {
-      input: (props: ObjectInputProps) =>
-        LinkInput({customLinkTypes, ...props, value: props.value as LinkValue}),
+      input: (props: ObjectInputProps) => (
+        <LinkInput customLinkTypes={customLinkTypes} {...props} value={props.value as LinkValue} />
+      ),
     },
   })
 


### PR DESCRIPTION
these components are not memoized, even when using react compiler. this is at least partially due to the syntax used to call them, which bypasses React.createElement()

fixes #26