### PR TITLE
chore: React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@sanity/pkg-utils": "^6.6.6",
     "@sanity/plugin-kit": "^4.0.4",
     "@sanity/semantic-release-preset": "^4.1.7",
-    "@types/react": "^18.2.79",
+    "@types/react": "^18.2.79 || ^19",
     "@typescript-eslint/eslint-plugin": "^7.7.0",
     "@typescript-eslint/parser": "^7.7.0",
     "eslint": "^8.0.0",
@@ -100,7 +100,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "react": "^18",
+    "react": "^18 || ^19",
     "sanity": "^3"
   },
   "engines": {


### PR DESCRIPTION
👋 Hi, @marcusforsberg — this simple pull request enables compatibility with React 19. Happy to make any changes if needed.

### Compatibility updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85-R85): Updated the `@types/react` dependency to support both React 18 and React 19 (`^18.2.79 || ^19`).
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L103-R103): Updated the `react` peer dependency to allow versions 18 and 19 (`^18 || ^19`).