### PR TITLE
chore: update peer dependency to support Sanity v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "peerDependencies": {
     "react": "^18",
-    "sanity": "^3"
+    "sanity": "^3 || ^4"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

- Updated peerDependencies in package.json to support both Sanity v3 and v4
- Eliminates the need for package overrides when using this plugin with Sanity v4
- Maintains backward compatibility with existing Sanity v3 installations