### PR TITLE
fix: typegen crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sanity/icons": "^3",
         "@sanity/incompatible-plugin": "^1.0.5",
         "@sanity/ui": "^3",
-        "lucide-react": "^0.475.0"
+        "lucide-react": "^0.576.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.4.0",
@@ -402,7 +402,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2167,6 +2166,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2524,7 +2524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2565,7 +2564,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2603,7 +2601,6 @@
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2703,6 +2700,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -2711,13 +2709,15 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -4576,7 +4576,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4889,7 +4888,6 @@
       "integrity": "sha512-h1jy7XHSINJxjl3HtnpV4LyTXY/M/38bXA76g3MPXjU8Inm4KwQdVW0mto5P60fsX8aFUVkGLXI/jATqluQ9hw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@portabletext/block-tools": "^5.0.1",
         "@portabletext/keyboard-shortcuts": "^2.1.2",
@@ -6502,7 +6500,6 @@
       "integrity": "sha512-lCDx0vuNUgg9FL2E5Hiv1q7u6iHd1Z+jjMZAaYtfzzFPoBKOiyZlaFwqyLVHRyTbwnXQdIGDPmx2AvfBTbGQsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.7.0",
@@ -7036,7 +7033,6 @@
       "integrity": "sha512-x6KNOG26XCTASfOofcYBPCfPR78lqN0Fz+Xy5SYs2iuvWN3vs8LZCYo0yiXR7MYpp+IpcV9JChzTM6yxeX7zMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.1.0",
         "@oclif/core": "^4.8.0",
@@ -8948,7 +8944,6 @@
       "integrity": "sha512-58frPNX55Je1YsyrtPJv9rOSR3G5efUZpRqok94Efsj0EUa8dnqJV3BldShyI7A+bVPleucOtzXHwVpJRcR0kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.89.0",
         "@rolldown/pluginutils": "1.0.0-beta.38",
@@ -9044,7 +9039,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9093,7 +9087,6 @@
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9686,7 +9679,6 @@
       "integrity": "sha512-Nsj5YAI/oO77muq/uKDt5/ZnStInc6DfR5TeL1ePWoPVAzLIga1vJRNK1oWH5MefNtWzGVlmyEjJxMZ4OBJWXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sanity/client": "^7.14.1",
         "@sanity/media-library-types": "^1.2.0"
@@ -9805,7 +9797,8 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
@@ -9832,6 +9825,7 @@
       "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -9909,6 +9903,7 @@
       "integrity": "sha512-qyqLS+aSGH1SfXIooBKjs7mvrv0deg8v+jemegfJg1kq6ji+GJV8CO08VJDEsvjp3O8XJmTTIAjjZbMzagzsdw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/core": "^7.0.0",
         "@octokit/plugin-paginate-rest": "^14.0.0",
@@ -9941,6 +9936,7 @@
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -9971,6 +9967,7 @@
       "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "universal-user-agent": "^7.0.2"
@@ -9985,6 +9982,7 @@
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^10.0.6",
         "@octokit/types": "^16.0.0",
@@ -9999,7 +9997,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
       "version": "14.0.0",
@@ -10007,6 +10006,7 @@
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -10023,6 +10023,7 @@
       "integrity": "sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
@@ -10041,6 +10042,7 @@
       "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "bottleneck": "^2.15.3"
@@ -10058,6 +10060,7 @@
       "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^11.0.2",
         "@octokit/request-error": "^7.0.2",
@@ -10075,6 +10078,7 @@
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -10088,6 +10092,7 @@
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
@@ -10098,6 +10103,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10108,6 +10114,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -10124,7 +10131,8 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@semantic-release/github/node_modules/clean-stack": {
       "version": "5.3.0",
@@ -10132,6 +10140,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -10148,6 +10157,7 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10161,6 +10171,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10174,6 +10185,7 @@
       "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -10183,7 +10195,8 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@semantic-release/npm": {
       "version": "13.1.3",
@@ -10191,6 +10204,7 @@
       "integrity": "sha512-q7zreY8n9V0FIP1Cbu63D+lXtRAVAIWb30MH5U3TdrfXt6r2MIrWCY0whAImN53qNvSGp0Zt07U95K+Qp9GpEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/core": "^2.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -10221,6 +10235,7 @@
       "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/exec": "^2.0.0",
         "@actions/http-client": "^3.0.2"
@@ -10232,6 +10247,7 @@
       "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/io": "^2.0.0"
       }
@@ -10242,6 +10258,7 @@
       "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^6.23.0"
@@ -10252,7 +10269,8 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
       "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
       "version": "4.0.0",
@@ -10260,6 +10278,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10270,6 +10289,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -10287,6 +10307,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -10303,6 +10324,7 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10316,6 +10338,7 @@
       "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -10343,6 +10366,7 @@
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -10359,6 +10383,7 @@
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -10376,6 +10401,7 @@
       "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -10389,6 +10415,7 @@
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -10399,6 +10426,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10412,6 +10440,7 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10425,6 +10454,7 @@
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10438,6 +10468,7 @@
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10451,6 +10482,7 @@
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -10461,6 +10493,7 @@
       "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^9.0.0",
         "semver": "^7.3.5",
@@ -10476,6 +10509,7 @@
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0",
         "unicorn-magic": "^0.3.0"
@@ -10493,6 +10527,7 @@
       "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "index-to-position": "^1.1.0",
@@ -10511,6 +10546,7 @@
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -10524,6 +10560,7 @@
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10537,6 +10574,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10550,6 +10588,7 @@
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -10566,6 +10605,7 @@
       "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.4",
         "normalize-package-data": "^8.0.0",
@@ -10586,6 +10626,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -10599,6 +10640,7 @@
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10612,6 +10654,7 @@
       "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "dependencies": {
         "tagged-tag": "^1.0.0"
       },
@@ -10628,6 +10671,7 @@
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.17"
       }
@@ -10638,6 +10682,7 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10651,6 +10696,7 @@
       "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
@@ -10676,6 +10722,7 @@
       "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -10689,6 +10736,7 @@
       "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -10701,7 +10749,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/normalize-package-data": {
       "version": "6.0.2",
@@ -10709,6 +10758,7 @@
       "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^7.0.0",
         "semver": "^7.3.5",
@@ -10724,6 +10774,7 @@
       "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "index-to-position": "^1.1.0",
@@ -10742,6 +10793,7 @@
       "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up-simple": "^1.0.0",
         "read-pkg": "^9.0.0",
@@ -10760,6 +10812,7 @@
       "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.3",
         "normalize-package-data": "^6.0.0",
@@ -10780,6 +10833,7 @@
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -10892,6 +10946,7 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11226,7 +11281,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -11272,6 +11326,7 @@
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -11282,7 +11337,8 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -11351,7 +11407,6 @@
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -11382,7 +11437,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11422,7 +11476,8 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/tar-stream": {
       "version": "3.1.4",
@@ -11514,7 +11569,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -11933,6 +11987,7 @@
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.4",
@@ -11950,6 +12005,7 @@
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
@@ -11977,6 +12033,7 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -11987,6 +12044,7 @@
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -12000,6 +12058,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -12015,6 +12074,7 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -12030,6 +12090,7 @@
       "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -12043,6 +12104,7 @@
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
@@ -12091,7 +12153,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12273,7 +12334,8 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -12510,7 +12572,8 @@
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
       "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -12690,6 +12753,7 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12926,7 +12990,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -13058,7 +13121,8 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -13114,7 +13178,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -13284,6 +13347,7 @@
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13349,6 +13413,7 @@
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -13379,6 +13444,7 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13426,6 +13492,7 @@
       "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -13489,6 +13556,7 @@
       "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "highlight.js": "^10.7.1",
@@ -13511,6 +13579,7 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13528,6 +13597,7 @@
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -13539,7 +13609,8 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-highlight/node_modules/supports-color": {
       "version": "7.2.0",
@@ -13547,6 +13618,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13560,6 +13632,7 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -13578,6 +13651,7 @@
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -13610,6 +13684,7 @@
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -13998,6 +14073,7 @@
       "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
@@ -14017,6 +14093,7 @@
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -14030,6 +14107,7 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14069,6 +14147,7 @@
       "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14110,7 +14189,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -14249,6 +14327,7 @@
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14275,6 +14354,7 @@
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -14582,6 +14662,7 @@
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14923,6 +15004,7 @@
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
@@ -14932,7 +15014,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/duplexer2/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -14940,6 +15023,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14955,7 +15039,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -14963,6 +15048,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -15071,7 +15157,8 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/empathic": {
       "version": "2.0.0",
@@ -15112,6 +15199,7 @@
       "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execa": "^8.0.0",
         "java-properties": "^1.0.2"
@@ -15126,6 +15214,7 @@
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -15150,6 +15239,7 @@
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -15163,6 +15253,7 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -15173,6 +15264,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -15186,6 +15278,7 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15199,6 +15292,7 @@
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -15215,6 +15309,7 @@
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -15231,6 +15326,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15244,6 +15340,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -15257,6 +15354,7 @@
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15280,6 +15378,7 @@
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -15488,7 +15587,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -15566,7 +15664,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15627,7 +15724,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -16160,6 +16256,7 @@
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -16194,7 +16291,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -16517,6 +16615,7 @@
       "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver-regex": "^4.0.5",
         "super-regex": "^1.0.0"
@@ -16792,6 +16891,7 @@
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -16802,7 +16902,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -16810,6 +16911,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16825,7 +16927,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -16833,6 +16936,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -16897,6 +17001,7 @@
       "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -17148,6 +17253,7 @@
       "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argv-formatter": "~1.0.0",
         "spawn-error-forwarder": "~1.0.0",
@@ -17163,6 +17269,7 @@
       "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "through2": "~2.0.0"
       }
@@ -17476,6 +17583,7 @@
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -17659,6 +17767,7 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -17703,6 +17812,7 @@
       "integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -17838,7 +17948,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -17966,6 +18075,7 @@
       "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
@@ -18021,6 +18131,7 @@
       "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18132,6 +18243,7 @@
       "integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "from2": "^2.3.0",
         "p-is-promise": "^3.0.0"
@@ -18873,6 +18985,7 @@
       "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.capitalize": "^4.2.1",
         "lodash.escaperegexp": "^4.1.2",
@@ -18942,6 +19055,7 @@
       "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -19003,7 +19117,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -19080,7 +19193,8 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -19790,6 +19904,7 @@
       "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -19806,6 +19921,7 @@
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -19820,6 +19936,7 @@
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -19873,7 +19990,8 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -19887,21 +20005,24 @@
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -19922,7 +20043,8 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -19989,7 +20111,8 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -20002,9 +20125,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.475.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.475.0.tgz",
-      "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
+      "version": "0.576.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.576.0.tgz",
+      "integrity": "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -20026,6 +20149,7 @@
       "integrity": "sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-event": "^6.0.0",
         "type-fest": "^4.6.0",
@@ -20044,6 +20168,7 @@
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -20133,6 +20258,7 @@
       "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "ansi-regex": "^6.1.0",
@@ -20155,6 +20281,7 @@
       "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "environment": "^1.0.0"
       },
@@ -20325,6 +20452,7 @@
         "https://github.com/sponsors/broofa"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -20567,6 +20695,7 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -20613,14 +20742,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nerf-dart": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nock": {
       "version": "14.0.10",
@@ -20643,6 +20774,7 @@
       "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
         "char-regex": "^1.0.2",
@@ -20832,6 +20964,7 @@
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -20913,6 +21046,7 @@
       ],
       "dev": true,
       "license": "Artistic-2.0",
+      "peer": true,
       "workspaces": [
         "docs",
         "smoke-tests",
@@ -21044,6 +21178,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -21053,6 +21188,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
       },
@@ -21065,6 +21201,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -21076,13 +21213,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -21099,6 +21238,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
@@ -21146,6 +21286,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -21165,6 +21306,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -21177,6 +21319,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^9.0.0",
         "ini": "^6.0.0",
@@ -21196,6 +21339,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-bundled": "^5.0.0",
         "npm-normalize-package-bin": "^5.0.0"
@@ -21212,6 +21356,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -21227,6 +21372,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cacache": "^20.0.0",
         "json-parse-even-better-errors": "^5.0.0",
@@ -21243,6 +21389,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21252,6 +21399,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21261,6 +21409,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "glob": "^13.0.0",
@@ -21279,6 +21428,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "which": "^6.0.0"
       },
@@ -21291,6 +21441,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
       },
@@ -21303,6 +21454,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21312,6 +21464,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -21329,6 +21482,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0"
       },
@@ -21341,6 +21495,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21350,6 +21505,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -21359,6 +21515,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.1.0",
@@ -21376,6 +21533,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
         "tuf-js": "^4.1.0"
@@ -21389,6 +21547,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.1.0",
@@ -21403,6 +21562,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -21412,6 +21572,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^10.1.1"
@@ -21425,6 +21586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21434,6 +21596,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -21443,6 +21606,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -21451,19 +21615,22 @@
       "version": "2.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cmd-shim": "^8.0.0",
         "npm-normalize-package-bin": "^5.0.0",
@@ -21480,6 +21647,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20"
       },
@@ -21492,6 +21660,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
@@ -21514,6 +21683,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -21526,6 +21696,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21541,6 +21712,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -21550,6 +21722,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "ip-regex": "5.0.0"
       },
@@ -21562,6 +21735,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
@@ -21575,6 +21749,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21584,6 +21759,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -21593,6 +21769,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -21605,6 +21782,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -21622,6 +21800,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -21630,7 +21809,8 @@
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -21638,6 +21818,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -21647,6 +21828,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -21655,19 +21837,22 @@
       "version": "2.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -21677,6 +21862,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -21689,6 +21875,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
@@ -21705,13 +21892,15 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "9.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -21723,13 +21912,15 @@
       "version": "4.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -21743,6 +21934,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -21757,6 +21949,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -21769,6 +21962,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.0.3"
       },
@@ -21781,6 +21975,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -21790,6 +21985,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21799,6 +21995,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^7.0.0",
         "npm-package-arg": "^13.0.0",
@@ -21817,6 +22014,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -21826,6 +22024,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -21838,6 +22037,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "cidr-regex": "5.0.1"
       },
@@ -21850,6 +22050,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -21859,6 +22060,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -21868,6 +22070,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -21877,6 +22080,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -21888,25 +22092,29 @@
         "node >= 0.2.0"
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-package-arg": "^13.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -21920,6 +22128,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.1.10",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -21939,6 +22148,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.1.10",
         "@npmcli/package-json": "^7.0.0",
@@ -21962,6 +22172,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.1.10"
       },
@@ -21974,6 +22185,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -21987,6 +22199,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.1.10",
         "@npmcli/run-script": "^10.0.0",
@@ -22002,6 +22215,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
@@ -22021,6 +22235,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^19.0.0"
       },
@@ -22033,6 +22248,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -22046,6 +22262,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
@@ -22062,6 +22279,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -22071,6 +22289,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/agent": "^4.0.0",
         "cacache": "^20.0.1",
@@ -22093,6 +22312,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -22108,6 +22328,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -22117,6 +22338,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -22129,6 +22351,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -22146,6 +22369,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -22158,6 +22382,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22170,6 +22395,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -22182,6 +22408,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22194,6 +22421,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -22206,6 +22434,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22218,6 +22447,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -22229,13 +22459,15 @@
       "version": "2.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22245,6 +22477,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -22254,6 +22487,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -22278,6 +22512,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "^4.0.0"
       },
@@ -22293,6 +22528,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22302,6 +22538,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^5.0.0"
       },
@@ -22314,6 +22551,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -22326,6 +22564,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22335,6 +22574,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^9.0.0",
         "proc-log": "^6.0.0",
@@ -22350,6 +22590,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ignore-walk": "^8.0.0",
         "proc-log": "^6.0.0"
@@ -22363,6 +22604,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-install-checks": "^8.0.0",
         "npm-normalize-package-bin": "^5.0.0",
@@ -22378,6 +22620,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0"
@@ -22391,6 +22634,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
@@ -22410,6 +22654,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22419,6 +22664,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -22431,6 +22677,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -22462,6 +22709,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^5.0.0",
         "just-diff": "^6.0.0",
@@ -22476,6 +22724,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -22492,6 +22741,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -22505,6 +22755,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22514,6 +22765,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22523,6 +22775,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -22532,6 +22785,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -22541,6 +22795,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -22554,6 +22809,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "read": "^5.0.0"
       },
@@ -22565,6 +22821,7 @@
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -22574,6 +22831,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "mute-stream": "^3.0.0"
       },
@@ -22586,6 +22844,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22595,6 +22854,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -22604,13 +22864,15 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -22623,6 +22885,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -22635,6 +22898,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.1.0",
@@ -22652,6 +22916,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -22662,6 +22927,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -22676,6 +22942,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -22690,6 +22957,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -22700,6 +22968,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -22709,13 +22978,15 @@
       "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -22725,13 +22996,15 @@
       "version": "3.0.22",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "13.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -22744,6 +23017,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -22758,6 +23032,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -22770,6 +23045,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -22782,6 +23058,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -22798,6 +23075,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -22806,19 +23084,22 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "2.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -22835,6 +23116,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -22865,6 +23147,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -22874,6 +23157,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/models": "4.1.0",
         "debug": "^4.4.3",
@@ -22888,6 +23172,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "unique-slug": "^6.0.0"
       },
@@ -22900,6 +23185,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -22911,13 +23197,15 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -22928,6 +23216,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -22938,6 +23227,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -22947,6 +23237,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -22956,6 +23247,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -22971,6 +23263,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -22983,7 +23276,8 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -23348,6 +23642,7 @@
       "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23361,6 +23656,7 @@
       "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-timeout": "^6.1.2"
       },
@@ -23377,6 +23673,7 @@
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -23390,6 +23687,7 @@
       "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-map": "^7.0.1"
       },
@@ -23406,6 +23704,7 @@
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -23429,6 +23728,7 @@
       "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -23704,6 +24004,7 @@
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^6.0.1"
       }
@@ -23713,7 +24014,8 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
@@ -23812,6 +24114,7 @@
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -23880,6 +24183,7 @@
       "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^2.0.0",
         "load-json-file": "^4.0.0"
@@ -23894,6 +24198,7 @@
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -23907,6 +24212,7 @@
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -23921,6 +24227,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -23934,6 +24241,7 @@
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -23947,6 +24255,7 @@
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -23957,6 +24266,7 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24168,7 +24478,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/preferred-pm": {
       "version": "4.1.1",
@@ -24201,7 +24512,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24499,7 +24809,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24531,7 +24840,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -24601,8 +24909,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refractor": {
       "version": "4.0.0",
@@ -24653,6 +24960,7 @@
       "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up-simple": "^1.0.1",
         "read-pkg": "^10.0.0",
@@ -24671,6 +24979,7 @@
       "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -24684,6 +24993,7 @@
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -24694,6 +25004,7 @@
       "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^9.0.0",
         "semver": "^7.3.5",
@@ -24709,6 +25020,7 @@
       "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "index-to-position": "^1.1.0",
@@ -24727,6 +25039,7 @@
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -24740,6 +25053,7 @@
       "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.4",
         "normalize-package-data": "^8.0.0",
@@ -24760,6 +25074,7 @@
       "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "dependencies": {
         "tagged-tag": "^1.0.0"
       },
@@ -24776,6 +25091,7 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -25325,7 +25641,6 @@
       "integrity": "sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.110.0",
         "@rolldown/pluginutils": "1.0.0-rc.1"
@@ -25470,7 +25785,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26371,6 +26685,7 @@
       "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26381,6 +26696,7 @@
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^5.2.0",
         "indent-string": "^5.0.0"
@@ -26398,6 +26714,7 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26411,6 +26728,7 @@
       "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "5.0.0"
       },
@@ -26427,6 +26745,7 @@
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^7.2.0",
         "strip-ansi": "^7.1.0",
@@ -26441,7 +26760,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-release/node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -26449,6 +26769,7 @@
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26462,6 +26783,7 @@
       "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -26489,6 +26811,7 @@
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -26506,6 +26829,7 @@
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -26522,6 +26846,7 @@
       "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -26535,6 +26860,7 @@
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -26545,6 +26871,7 @@
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26558,6 +26885,7 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26571,6 +26899,7 @@
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26584,6 +26913,7 @@
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26597,6 +26927,7 @@
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -26607,6 +26938,7 @@
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0",
         "unicorn-magic": "^0.3.0"
@@ -26624,6 +26956,7 @@
       "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26637,6 +26970,7 @@
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26650,6 +26984,7 @@
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26663,6 +26998,7 @@
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -26679,6 +27015,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -26692,6 +27029,7 @@
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -26710,6 +27048,7 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -26726,6 +27065,7 @@
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26739,6 +27079,7 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -26752,6 +27093,7 @@
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -26770,6 +27112,7 @@
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
@@ -26788,6 +27131,7 @@
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
@@ -26812,6 +27156,7 @@
       "deprecated": "Deprecated as the semver package now supports this built-in.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -26828,6 +27173,7 @@
       "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26925,7 +27271,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -27044,7 +27391,8 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -27059,6 +27407,7 @@
       "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
@@ -27074,6 +27423,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -27087,6 +27437,7 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -27102,6 +27453,7 @@
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -27111,7 +27463,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/signale/node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -27119,6 +27472,7 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -27129,6 +27483,7 @@
       "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -27142,6 +27497,7 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -27152,6 +27508,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -27192,6 +27549,7 @@
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
       },
@@ -27217,8 +27575,7 @@
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.120.0.tgz",
       "integrity": "sha512-CXK/DADGgMZb4z9RTtXylzIDOxvmNJEF9bXV2bAGkLWhQ3rm7GORY9q0H/W41YJvAGZsLbH7nnrhMYr550hWDQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/slate-dom": {
       "version": "0.119.0",
@@ -27370,7 +27727,8 @@
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -27447,14 +27805,16 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -27489,6 +27849,7 @@
       "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -27499,7 +27860,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-combiner2/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -27507,6 +27869,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -27522,7 +27885,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-combiner2/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -27530,6 +27894,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -27808,6 +28173,7 @@
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -27820,7 +28186,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stubborn-fs": {
       "version": "2.0.0",
@@ -27844,6 +28211,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
       "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -27891,6 +28259,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -27904,7 +28273,8 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/super-regex": {
       "version": "1.1.0",
@@ -27912,6 +28282,7 @@
       "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-timeout": "^1.0.1",
         "make-asynchronous": "^1.0.1",
@@ -27946,6 +28317,7 @@
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -27963,6 +28335,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -28012,6 +28385,7 @@
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -28078,6 +28452,7 @@
       "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -28088,6 +28463,7 @@
       "integrity": "sha512-pD3+21EbFZFBKDnVztX32wU6IBwkalOduWdx1OKvB5y6y1f2Xn8HU/U6o9EmlfdSyUYe9IybirmYPj/7rilA6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-stream": "^3.0.0",
         "temp-dir": "^3.0.0",
@@ -28107,6 +28483,7 @@
       "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^1.0.1"
       },
@@ -28123,6 +28500,7 @@
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -28136,6 +28514,7 @@
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -28149,6 +28528,7 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -28162,6 +28542,7 @@
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crypto-random-string": "^4.0.0"
       },
@@ -28207,6 +28588,7 @@
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -28217,6 +28599,7 @@
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -28288,6 +28671,7 @@
       "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "convert-hrtime": "^5.0.0"
       },
@@ -28310,7 +28694,8 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -28345,6 +28730,7 @@
       "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -28355,6 +28741,7 @@
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28365,6 +28752,7 @@
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28457,6 +28845,7 @@
       "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -28729,7 +29118,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28783,6 +29171,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -28852,6 +29241,7 @@
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -28896,6 +29286,7 @@
       "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -29035,6 +29426,7 @@
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -29141,7 +29533,6 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -29220,7 +29611,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -29363,6 +29753,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -29435,7 +29826,8 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
@@ -29482,7 +29874,8 @@
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -29676,6 +30069,7 @@
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -30220,7 +30614,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@sanity/icons": "^3",
     "@sanity/incompatible-plugin": "^1.0.5",
     "@sanity/ui": "^3",
-    "lucide-react": "^0.475.0"
+    "lucide-react": "^0.576.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.0",
@@ -81,14 +81,14 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "typescript-eslint": "^8",
     "lefthook": "^2.0.16",
     "prettier": "^3.8.1",
     "prettier-plugin-packagejson": "^3.0.0",
     "react": "^19",
     "react-dom": "^19",
     "sanity": "^5.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8"
   },
   "peerDependencies": {
     "react": "^18 || ^19",


### PR DESCRIPTION
Recently this package started failing sanity type generation. 

After some investigation the issue ended up being an old version of lucide-react.

This is coincidentally fixed by #35 but since it sounds like that might be a major. I thought it would be good to patch the latest to fix the issue for `1.x`.

----

The error given by the initial type generation is unintentionally quite vague:
```
✗ Failed to extract schema

SchemaExtractionError: Failed to load configuration file "/Users/robbie/programming/work/temple-st-clair/sanity.config.ts"
    at extractSchemaToFile (~/Library/pnpm/store/v10/links/@/sanity/5.12.0/8b782502ab73f1de24fce6b51a662683ebb3e6bff4637cb40b664d59a563c13d/node_modules/sanity/src/_internal/cli/actions/schema/schemaExtractorApi.ts:92:11)
    at async runSingleExtraction (~/Library/pnpm/store/v10/links/@/sanity/5.12.0/8b782502ab73f1de24fce6b51a662683ebb3e6bff4637cb40b664d59a563c13d/node_modules/sanity/src/_internal/cli/actions/schema/extractAction.ts:87:20)
```

Luckily, we can validate the schema to view the full error.
Here's the full error text:
```
> pnpm exec sanity schema validate
⠴ Validating schema…Error: Failed to load configuration file "/Users/<user>/programming/work/<project>/sanity.config.ts"
    at getStudioConfig (/Users/<user>/Library/pnpm/store/v10/links/@/sanity/5.12.0/.../node_modules/sanity/lib/_chunks-cjs/getStudioWorkspaces.cjs:25:13)
    at Object.getStudioWorkspaces (/Users/<user>/Library/pnpm/store/v10/links/@/sanity/5.12.0/.../node_modules/sanity/lib/_chunks-cjs/getStudioWorkspaces.cjs:43:20)
    at main (/Users/<user>/Library/pnpm/store/v10/links/@/sanity/5.12.0/.../node_modules/sanity/lib/_internal/cli/threads/validateSchema.cjs:14:50)
    at Object.<anonymous> (/Users/<user>/Library/pnpm/store/v10/links/@/sanity/5.12.0/.../node_modules/sanity/lib/_internal/cli/threads/validateSchema.cjs:107:1)
    at Module._compile (node:internal/modules/cjs/loader:1812:14)
    at Object.<anonymous> (node:internal/modules/cjs/loader:1943:10)
    at Module.load (node:internal/modules/cjs/loader:1533:32)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1335:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5) {
  [cause]: ReferenceError: require is not defined in ES module scope, you can use import instead
  This file is being treated as an ES module because it has a '.js' file extension and '/Users/<user>/Library/pnpm/store/v10/links/@/lucide-react/0.475.0/.../node_modules/lucide-react/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
      at file:///Users/<user>/Library/pnpm/store/v10/links/@/lucide-react/0.475.0/.../node_modules/lucide-react/dist/cjs/lucide-react.js:10:13
      at ModuleJobSync.runSync (node:internal/modules/esm/module_job:534:37)
      at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:388:47)
      at loadESMFromCJS (node:internal/modules/cjs/loader:1629:24)
      at Module._compile (node:internal/modules/cjs/loader:1794:5)
      at node:internal/modules/cjs/loader:1943:10
      at Object.newLoader (/Users/<user>/Library/pnpm/store/v10/links/@/esbuild-register/3.6.0/.../node_modules/esbuild-register/dist/node.js:2262:9)
      at extensions..js (/Users/<user>/Library/pnpm/store/v10/links/@/esbuild-register/3.6.0/.../node_modules/esbuild-register/dist/node.js:4833:24)
      at Module.load (node:internal/modules/cjs/loader:1533:32)
      at Module.<anonymous> (node:internal/modules/cjs/loader:1335:12)
}

> pnpm why lucide-react
lucide-react@0.475.0
└─┬ sanity-plugin-link-field@1.5.0
  └── website (dependencies)
```