### PR TITLE
fix: prevent stale references and type desync when switching link type

### DIFF
--- a/src/components/LinkInput.tsx
+++ b/src/components/LinkInput.tsx
@@ -82,6 +82,7 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
         <Flex gap={2} align="flex-start">
           {/* Render the type field (without its label) */}
           <ObjectInputMember
+            key={typeField.name}
             member={{
               ...typeField,
               field: {
@@ -98,6 +99,7 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
           <Stack space={2} style={{width: '100%'}}>
             {/* Render the input for the selected type of link (without its label) */}
             <ObjectInputMember
+              key={linkField.name}
               member={{
                 ...linkField,
                 field: {

--- a/src/components/LinkInput.tsx
+++ b/src/components/LinkInput.tsx
@@ -5,7 +5,7 @@ import {FormFieldValidationStatus, ObjectInputMember, PatchEvent} from 'sanity'
 import {resolveLinkInputMembers} from '../helpers/linkInputMembers'
 import {createLinkTypeChangePatches} from '../helpers/typeChangePatches'
 import {isCustomLink} from '../helpers/typeGuards'
-import {LinkInputProps} from '../types'
+import type {LinkInputProps} from '../types'
 
 import {LinkTypeChangeContext} from './linkTypeChangeContext'
 
@@ -64,7 +64,7 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
 
   return (
     <LinkTypeChangeContext.Provider value={handleLinkTypeChange}>
-      <Stack space={4}>
+      <Stack gap={4}>
         {/* Render the text field if enabled */}
         {options?.enableText && textField && (
           <ObjectInputMember
@@ -82,7 +82,7 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
           />
         )}
 
-        <Stack space={3}>
+        <Stack gap={3}>
           {/* Render a label for the link field if there's also a text field enabled. */}
           {/* If there's no text field, the label here is irrelevant */}
           {options?.enableText && (
@@ -108,7 +108,7 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
               {...renderProps}
             />
 
-            <Stack space={2} style={{width: '100%'}}>
+            <Stack gap={2} style={{width: '100%'}}>
               {/* Render the input for the selected type of link (without its label) */}
               <ObjectInputMember
                 key={linkField.name}

--- a/src/components/LinkInput.tsx
+++ b/src/components/LinkInput.tsx
@@ -1,10 +1,13 @@
 import {Box, Flex, Stack, Text} from '@sanity/ui'
-import {memo} from 'react'
-import {FormFieldValidationStatus, ObjectInputMember} from 'sanity'
+import {memo, useCallback} from 'react'
+import {FormFieldValidationStatus, ObjectInputMember, PatchEvent} from 'sanity'
 
 import {resolveLinkInputMembers} from '../helpers/linkInputMembers'
+import {createLinkTypeChangePatches} from '../helpers/typeChangePatches'
 import {isCustomLink} from '../helpers/typeGuards'
 import {LinkInputProps} from '../types'
+
+import {LinkTypeChangeContext} from './linkTypeChangeContext'
 
 /**
  * Custom input component for the link object.
@@ -14,9 +17,17 @@ import {LinkInputProps} from '../types'
  * The rest of the fields ("blank" and "advanced") are rendered as usual.
  */
 export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
+  const {onChange} = props
   const {textField, typeField, linkField, otherFields} = resolveLinkInputMembers(
     props.members,
     props.value,
+  )
+
+  const handleLinkTypeChange = useCallback(
+    (nextType: string) => {
+      onChange(PatchEvent.from(createLinkTypeChangePatches(nextType)))
+    },
+    [onChange],
   )
 
   // In Sanity Studio v6, `members` can be undefined while form state is resolving.
@@ -52,60 +63,44 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
   }
 
   return (
-    <Stack space={4}>
-      {/* Render the text field if enabled */}
-      {options?.enableText && textField && (
-        <ObjectInputMember
-          member={{
-            ...textField,
-            field: {
-              ...textField.field,
-              schemaType: {
-                ...textField.field.schemaType,
-                title: options?.textLabel || textField.field.schemaType.title,
-              },
-            },
-          }}
-          {...renderProps}
-        />
-      )}
-
-      <Stack space={3}>
-        {/* Render a label for the link field if there's also a text field enabled. */}
-        {/* If there's no text field, the label here is irrelevant */}
-        {options?.enableText && (
-          <Text as="label" weight="medium" size={1}>
-            Link
-          </Text>
-        )}
-
-        <Flex gap={2} align="flex-start">
-          {/* Render the type field (without its label) */}
+    <LinkTypeChangeContext.Provider value={handleLinkTypeChange}>
+      <Stack space={4}>
+        {/* Render the text field if enabled */}
+        {options?.enableText && textField && (
           <ObjectInputMember
-            key={typeField.name}
             member={{
-              ...typeField,
+              ...textField,
               field: {
-                ...typeField.field,
+                ...textField.field,
                 schemaType: {
-                  ...typeField.field.schemaType,
-                  title: undefined,
+                  ...textField.field.schemaType,
+                  title: options?.textLabel || textField.field.schemaType.title,
                 },
               },
             }}
             {...renderProps}
           />
+        )}
 
-          <Stack space={2} style={{width: '100%'}}>
-            {/* Render the input for the selected type of link (without its label) */}
+        <Stack space={3}>
+          {/* Render a label for the link field if there's also a text field enabled. */}
+          {/* If there's no text field, the label here is irrelevant */}
+          {options?.enableText && (
+            <Text as="label" weight="medium" size={1}>
+              Link
+            </Text>
+          )}
+
+          <Flex gap={2} align="flex-start">
+            {/* Render the type field (without its label) */}
             <ObjectInputMember
-              key={linkField.name}
+              key={typeField.name}
               member={{
-                ...linkField,
+                ...typeField,
                 field: {
-                  ...linkField.field,
+                  ...typeField.field,
                   schemaType: {
-                    ...linkField.field.schemaType,
+                    ...typeField.field.schemaType,
                     title: undefined,
                   },
                 },
@@ -113,38 +108,56 @@ export const LinkInput = memo(function LinkInput(props: LinkInputProps) {
               {...renderProps}
             />
 
-            {/* Render any validation errors for the link field */}
-            {linkFieldValidation.length > 0 && (
-              <Box
-                style={{
-                  contain: 'size',
-                  marginBottom: '6px',
-                  marginLeft: 'auto',
-                  marginRight: '12px',
+            <Stack space={2} style={{width: '100%'}}>
+              {/* Render the input for the selected type of link (without its label) */}
+              <ObjectInputMember
+                key={linkField.name}
+                member={{
+                  ...linkField,
+                  field: {
+                    ...linkField.field,
+                    schemaType: {
+                      ...linkField.field.schemaType,
+                      title: undefined,
+                    },
+                  },
                 }}
-              >
-                <FormFieldValidationStatus
-                  fontSize={1}
-                  placement="top"
-                  validation={linkFieldValidation}
-                />
-              </Box>
-            )}
-          </Stack>
-        </Flex>
+                {...renderProps}
+              />
 
-        {/* Render the description of the selected link field, if any */}
-        {description && (
-          <Text muted size={1}>
-            {description}
-          </Text>
-        )}
+              {/* Render any validation errors for the link field */}
+              {linkFieldValidation.length > 0 && (
+                <Box
+                  style={{
+                    contain: 'size',
+                    marginBottom: '6px',
+                    marginLeft: 'auto',
+                    marginRight: '12px',
+                  }}
+                >
+                  <FormFieldValidationStatus
+                    fontSize={1}
+                    placement="top"
+                    validation={linkFieldValidation}
+                  />
+                </Box>
+              )}
+            </Stack>
+          </Flex>
+
+          {/* Render the description of the selected link field, if any */}
+          {description && (
+            <Text muted size={1}>
+              {description}
+            </Text>
+          )}
+        </Stack>
+
+        {/* Render the rest of the fields as usual */}
+        {otherFields.map((field) => (
+          <ObjectInputMember key={field.key} member={field} {...renderProps} />
+        ))}
       </Stack>
-
-      {/* Render the rest of the fields as usual */}
-      {otherFields.map((field) => (
-        <ObjectInputMember key={field.key} member={field} {...renderProps} />
-      ))}
-    </Stack>
+    </LinkTypeChangeContext.Provider>
   )
 })

--- a/src/components/LinkTypeInput.tsx
+++ b/src/components/LinkTypeInput.tsx
@@ -2,9 +2,10 @@ import {ChevronDownIcon} from '@sanity/icons'
 import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
 import {AtSignIcon, GlobeIcon, LinkIcon, PhoneIcon, type LucideIcon} from 'lucide-react'
 import {type ComponentType, memo} from 'react'
-import {set, type StringInputProps} from 'sanity'
+import {PatchEvent, set, unset, type StringInputProps} from 'sanity'
 
-import {CustomLinkType, LinkFieldPluginOptions, LinkType} from '../types'
+import {getInactiveLinkFieldNames} from '../helpers/typeChangePatches'
+import type {CustomLinkType, LinkFieldPluginOptions, LinkType} from '../types'
 
 const ICON_SIZE = 16
 
@@ -88,7 +89,16 @@ export const LinkTypeInput = memo(function LinkTypeInput({
               text={type.title}
               icon={getIcon(type)}
               onClick={() => {
-                onChange(set(type.value))
+                if (type.value === value) {
+                  return
+                }
+
+                onChange(
+                  PatchEvent.from([
+                    set(type.value),
+                    ...getInactiveLinkFieldNames(type.value).map((field) => unset([field])),
+                  ]),
+                )
               }}
             />
           ))}

--- a/src/components/LinkTypeInput.tsx
+++ b/src/components/LinkTypeInput.tsx
@@ -1,11 +1,13 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
 import {AtSignIcon, GlobeIcon, LinkIcon, PhoneIcon, type LucideIcon} from 'lucide-react'
-import {type ComponentType, memo} from 'react'
-import {PatchEvent, set, unset, type StringInputProps} from 'sanity'
+import {type ComponentType, memo, useContext} from 'react'
+import type {StringInputProps} from 'sanity'
 
-import {getInactiveLinkFieldNames} from '../helpers/typeChangePatches'
+import {applyLinkTypeChange} from '../helpers/typeChangePatches'
 import type {CustomLinkType, LinkFieldPluginOptions, LinkType} from '../types'
+
+import {LinkTypeChangeContext} from './linkTypeChangeContext'
 
 const ICON_SIZE = 16
 
@@ -57,6 +59,8 @@ export const LinkTypeInput = memo(function LinkTypeInput({
   customLinkTypes?: CustomLinkType[]
   linkableSchemaTypes: LinkFieldPluginOptions['linkableSchemaTypes']
 }) {
+  const changeLinkType = useContext(LinkTypeChangeContext)
+
   const linkTypes = [
     // Disable internal links if not enabled for any schema types
     ...defaultLinkTypes.filter(
@@ -89,16 +93,12 @@ export const LinkTypeInput = memo(function LinkTypeInput({
               text={type.title}
               icon={getIcon(type)}
               onClick={() => {
-                if (type.value === value) {
-                  return
-                }
-
-                onChange(
-                  PatchEvent.from([
-                    set(type.value),
-                    ...getInactiveLinkFieldNames(type.value).map((field) => unset([field])),
-                  ]),
-                )
+                applyLinkTypeChange({
+                  nextType: type.value,
+                  currentType: value,
+                  changeLinkType,
+                  fieldOnChange: onChange,
+                })
               }}
             />
           ))}

--- a/src/components/LinkTypeInput.tsx
+++ b/src/components/LinkTypeInput.tsx
@@ -1,6 +1,6 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
-import {AtSignIcon, GlobeIcon, LinkIcon, PhoneIcon, type LucideIcon} from 'lucide-react'
+import {AtSignIcon, GlobeIcon, LinkIcon, type LucideIcon, PhoneIcon} from 'lucide-react'
 import {type ComponentType, memo, useContext} from 'react'
 import type {StringInputProps} from 'sanity'
 

--- a/src/components/linkTypeChangeContext.ts
+++ b/src/components/linkTypeChangeContext.ts
@@ -1,0 +1,8 @@
+import {createContext} from 'react'
+
+/**
+ * Object-scoped type-change handler provided by {@link LinkInput}.
+ * Using the link object's onChange keeps unset patches on sibling fields
+ * (`url`, `internalLink`, …) instead of nesting them under `type`.
+ */
+export const LinkTypeChangeContext = createContext<((nextType: string) => void) | null>(null)

--- a/src/helpers/linkInputMembers.test.ts
+++ b/src/helpers/linkInputMembers.test.ts
@@ -1,7 +1,7 @@
 import type {FieldMember, ObjectMember} from 'sanity'
 import {describe, expect, it} from 'vitest'
 
-import {resolveLinkInputMembers} from './linkInputMembers'
+import {getActiveLinkFieldName, resolveLinkInputMembers} from './linkInputMembers'
 
 function fieldMember(name: string): FieldMember {
   return {
@@ -18,6 +18,20 @@ function fieldsetMember(key: string): ObjectMember {
     name: key,
   } as unknown as ObjectMember
 }
+
+describe('getActiveLinkFieldName', () => {
+  it('returns the correct field name for built-in link types', () => {
+    expect(getActiveLinkFieldName('internal')).toBe('internalLink')
+    expect(getActiveLinkFieldName('external')).toBe('url')
+    expect(getActiveLinkFieldName('email')).toBe('email')
+    expect(getActiveLinkFieldName('phone')).toBe('phone')
+  })
+
+  it('falls back to value for custom link types', () => {
+    expect(getActiveLinkFieldName('archive')).toBe('value')
+    expect(getActiveLinkFieldName(undefined)).toBe('value')
+  })
+})
 
 describe('resolveLinkInputMembers', () => {
   it('returns empty otherFields when members is undefined', () => {
@@ -106,5 +120,34 @@ describe('resolveLinkInputMembers', () => {
     expect(resolveLinkInputMembers(members, {type: 'email'}).linkField).toBe(emailField)
     expect(resolveLinkInputMembers(members, {type: 'phone'}).linkField).toBe(phoneField)
     expect(resolveLinkInputMembers(members, {type: 'archive'}).linkField).toBe(valueField)
+  })
+
+  it('resolves link field when fieldset appears before core fields', () => {
+    const typeField = fieldMember('type')
+    const internalLinkField = fieldMember('internalLink')
+    const urlField = fieldMember('url')
+    const advancedFieldset = fieldsetMember('advanced')
+    const blankField = fieldMember('blank')
+
+    const result = resolveLinkInputMembers(
+      [advancedFieldset, blankField, urlField, typeField, internalLinkField],
+      {type: 'internal'},
+    )
+
+    expect(result.typeField).toBe(typeField)
+    expect(result.linkField).toBe(internalLinkField)
+    expect(result.otherFields).toEqual([advancedFieldset, blankField])
+  })
+
+  it('selects url when both internalLink and url members exist for external type', () => {
+    const typeField = fieldMember('type')
+    const internalLinkField = fieldMember('internalLink')
+    const urlField = fieldMember('url')
+
+    const result = resolveLinkInputMembers([typeField, internalLinkField, urlField], {
+      type: 'external',
+    })
+
+    expect(result.linkField).toBe(urlField)
   })
 })

--- a/src/helpers/linkInputMembers.ts
+++ b/src/helpers/linkInputMembers.ts
@@ -4,7 +4,7 @@ import type {LinkValue} from '../types'
 
 const LINK_VALUE_FIELD_NAMES = new Set(['internalLink', 'url', 'email', 'phone', 'value'])
 
-function getActiveLinkFieldName(type: LinkValue['type'] | undefined): string {
+export function getActiveLinkFieldName(type: LinkValue['type'] | undefined): string {
   switch (type) {
     case 'internal':
       return 'internalLink'

--- a/src/helpers/linkInputMembers.ts
+++ b/src/helpers/linkInputMembers.ts
@@ -2,7 +2,11 @@ import type {FieldMember, ObjectMember} from 'sanity'
 
 import type {LinkValue} from '../types'
 
-const LINK_VALUE_FIELD_NAMES = new Set(['internalLink', 'url', 'email', 'phone', 'value'])
+export const LINK_VALUE_FIELD_NAMES = ['internalLink', 'url', 'email', 'phone', 'value'] as const
+
+export type LinkValueFieldName = (typeof LINK_VALUE_FIELD_NAMES)[number]
+
+const LINK_VALUE_FIELD_NAME_SET: ReadonlySet<string> = new Set(LINK_VALUE_FIELD_NAMES)
 
 export function getActiveLinkFieldName(type: LinkValue['type'] | undefined): string {
   switch (type) {
@@ -45,7 +49,7 @@ export function resolveLinkInputMembers(
     }
 
     // Inactive link-type fields stay in `members` but are rendered via `linkField`.
-    if (member.kind === 'field' && LINK_VALUE_FIELD_NAMES.has(member.name)) {
+    if (member.kind === 'field' && LINK_VALUE_FIELD_NAME_SET.has(member.name)) {
       return false
     }
 

--- a/src/helpers/typeChangePatches.test.ts
+++ b/src/helpers/typeChangePatches.test.ts
@@ -1,6 +1,10 @@
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
-import {getInactiveLinkFieldNames} from './typeChangePatches'
+import {
+  applyLinkTypeChange,
+  createLinkTypeChangePatches,
+  getInactiveLinkFieldNames,
+} from './typeChangePatches'
 
 describe('getInactiveLinkFieldNames', () => {
   it('returns all link value fields except the active one for built-in types', () => {
@@ -17,5 +21,99 @@ describe('getInactiveLinkFieldNames', () => {
 
   it('keeps value and clears built-in link fields for custom types', () => {
     expect(getInactiveLinkFieldNames('archive')).toEqual(['internalLink', 'url', 'email', 'phone'])
+  })
+})
+
+describe('createLinkTypeChangePatches', () => {
+  it('sets type on the link object and unsets sibling value fields', () => {
+    const patches = createLinkTypeChangePatches('external')
+
+    expect(patches).toMatchObject([
+      {type: 'set', path: ['type'], value: 'external'},
+      {type: 'unset', path: ['internalLink']},
+      {type: 'unset', path: ['email']},
+      {type: 'unset', path: ['phone']},
+      {type: 'unset', path: ['value']},
+    ])
+  })
+
+  it('does not nest unset paths under the type field', () => {
+    const patches = createLinkTypeChangePatches('internal')
+
+    for (const patch of patches) {
+      if (patch.type === 'unset') {
+        expect(patch.path[0]).not.toBe('type')
+        expect(patch.path).toHaveLength(1)
+      }
+    }
+  })
+
+  it('keeps the active field for the next type', () => {
+    const externalPatches = createLinkTypeChangePatches('external')
+    expect(externalPatches.some((patch) => patch.type === 'unset' && patch.path[0] === 'url')).toBe(
+      false,
+    )
+
+    const customPatches = createLinkTypeChangePatches('archive')
+    expect(customPatches.some((patch) => patch.type === 'unset' && patch.path[0] === 'value')).toBe(
+      false,
+    )
+    expect(customPatches).toMatchObject([
+      {type: 'set', path: ['type'], value: 'archive'},
+      {type: 'unset', path: ['internalLink']},
+      {type: 'unset', path: ['url']},
+      {type: 'unset', path: ['email']},
+      {type: 'unset', path: ['phone']},
+    ])
+  })
+})
+
+describe('applyLinkTypeChange', () => {
+  it('is a no-op when the selected type is unchanged', () => {
+    const changeLinkType = vi.fn()
+    const fieldOnChange = vi.fn()
+
+    applyLinkTypeChange({
+      nextType: 'internal',
+      currentType: 'internal',
+      changeLinkType,
+      fieldOnChange,
+    })
+
+    expect(changeLinkType).not.toHaveBeenCalled()
+    expect(fieldOnChange).not.toHaveBeenCalled()
+  })
+
+  it('uses the object-scoped handler when available', () => {
+    const changeLinkType = vi.fn()
+    const fieldOnChange = vi.fn()
+
+    applyLinkTypeChange({
+      nextType: 'external',
+      currentType: 'internal',
+      changeLinkType,
+      fieldOnChange,
+    })
+
+    expect(changeLinkType).toHaveBeenCalledWith('external')
+    expect(fieldOnChange).not.toHaveBeenCalled()
+  })
+
+  it('falls back to field-scoped set when no object handler exists', () => {
+    const fieldOnChange = vi.fn()
+
+    applyLinkTypeChange({
+      nextType: 'email',
+      currentType: 'internal',
+      changeLinkType: null,
+      fieldOnChange,
+    })
+
+    expect(fieldOnChange).toHaveBeenCalledTimes(1)
+    expect(fieldOnChange.mock.calls[0]?.[0]).toMatchObject({
+      type: 'set',
+      path: [],
+      value: 'email',
+    })
   })
 })

--- a/src/helpers/typeChangePatches.test.ts
+++ b/src/helpers/typeChangePatches.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it} from 'vitest'
+
+import {getInactiveLinkFieldNames} from './typeChangePatches'
+
+describe('getInactiveLinkFieldNames', () => {
+  it('returns all link value fields except the active one for built-in types', () => {
+    expect(getInactiveLinkFieldNames('internal')).toEqual(['url', 'email', 'phone', 'value'])
+    expect(getInactiveLinkFieldNames('external')).toEqual([
+      'internalLink',
+      'email',
+      'phone',
+      'value',
+    ])
+    expect(getInactiveLinkFieldNames('email')).toEqual(['internalLink', 'url', 'phone', 'value'])
+    expect(getInactiveLinkFieldNames('phone')).toEqual(['internalLink', 'url', 'email', 'value'])
+  })
+
+  it('keeps value and clears built-in link fields for custom types', () => {
+    expect(getInactiveLinkFieldNames('archive')).toEqual(['internalLink', 'url', 'email', 'phone'])
+  })
+})

--- a/src/helpers/typeChangePatches.ts
+++ b/src/helpers/typeChangePatches.ts
@@ -1,4 +1,4 @@
-import {set, unset, type FormPatch, type PatchEvent} from 'sanity'
+import {type FormPatch, type PatchEvent, set, unset} from 'sanity'
 
 import type {LinkValue} from '../types'
 

--- a/src/helpers/typeChangePatches.ts
+++ b/src/helpers/typeChangePatches.ts
@@ -1,10 +1,14 @@
+import {set, unset, type FormPatch, type PatchEvent} from 'sanity'
+
 import type {LinkValue} from '../types'
 
-import {getActiveLinkFieldName} from './linkInputMembers'
+import {
+  getActiveLinkFieldName,
+  LINK_VALUE_FIELD_NAMES,
+  type LinkValueFieldName,
+} from './linkInputMembers'
 
-export const LINK_VALUE_FIELD_NAMES = ['internalLink', 'url', 'email', 'phone', 'value'] as const
-
-export type LinkValueFieldName = (typeof LINK_VALUE_FIELD_NAMES)[number]
+export type {LinkValueFieldName}
 
 /**
  * Returns link value field names that should be cleared when switching to `nextType`.
@@ -15,4 +19,45 @@ export function getInactiveLinkFieldNames(
   const activeField = getActiveLinkFieldName(nextType as LinkValue['type']) as LinkValueFieldName
 
   return LINK_VALUE_FIELD_NAMES.filter((name) => name !== activeField)
+}
+
+/**
+ * Builds patches relative to the link object for a type change.
+ *
+ * These must be applied via the link object's `onChange` (not the nested `type`
+ * string input). Field-scoped `onChange` prefixes every patch with `type`, which
+ * would turn sibling clears like `unset(['url'])` into `unset(['type', 'url'])`.
+ */
+export function createLinkTypeChangePatches(nextType: string): FormPatch[] {
+  return [
+    set(nextType, ['type']),
+    ...getInactiveLinkFieldNames(nextType).map((field) => unset([field])),
+  ]
+}
+
+/**
+ * Applies a link type selection from the type input.
+ *
+ * Prefers an object-scoped handler (from LinkInput) so inactive sibling fields
+ * are cleared correctly. Falls back to a field-scoped set when that handler is
+ * unavailable (e.g. default object input fallback).
+ */
+export function applyLinkTypeChange(options: {
+  nextType: string
+  currentType: string | undefined
+  changeLinkType: ((nextType: string) => void) | null
+  fieldOnChange: (patch: FormPatch | FormPatch[] | PatchEvent) => void
+}): void {
+  const {nextType, currentType, changeLinkType, fieldOnChange} = options
+
+  if (nextType === currentType) {
+    return
+  }
+
+  if (changeLinkType) {
+    changeLinkType(nextType)
+    return
+  }
+
+  fieldOnChange(set(nextType))
 }

--- a/src/helpers/typeChangePatches.ts
+++ b/src/helpers/typeChangePatches.ts
@@ -1,0 +1,18 @@
+import type {LinkValue} from '../types'
+
+import {getActiveLinkFieldName} from './linkInputMembers'
+
+export const LINK_VALUE_FIELD_NAMES = ['internalLink', 'url', 'email', 'phone', 'value'] as const
+
+export type LinkValueFieldName = (typeof LINK_VALUE_FIELD_NAMES)[number]
+
+/**
+ * Returns link value field names that should be cleared when switching to `nextType`.
+ */
+export function getInactiveLinkFieldNames(
+  nextType: LinkValue['type'] | string,
+): LinkValueFieldName[] {
+  const activeField = getActiveLinkFieldName(nextType as LinkValue['type']) as LinkValueFieldName
+
+  return LINK_VALUE_FIELD_NAMES.filter((name) => name !== activeField)
+}

--- a/src/helpers/validateLinkConsistency.test.ts
+++ b/src/helpers/validateLinkConsistency.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest'
+
+import type {LinkValue} from '../types'
+
+import {validateLinkTypeConsistency} from './validateLinkConsistency'
+
+describe('validateLinkTypeConsistency', () => {
+  it('passes for consistent internal and external links', () => {
+    expect(
+      validateLinkTypeConsistency({
+        type: 'internal',
+        internalLink: {_ref: 'page-1', _type: 'reference'},
+      } as LinkValue),
+    ).toBe(true)
+
+    expect(
+      validateLinkTypeConsistency({
+        type: 'external',
+        url: 'https://example.com',
+      } as LinkValue),
+    ).toBe(true)
+  })
+
+  it('flags external type with internal reference but no URL', () => {
+    expect(
+      validateLinkTypeConsistency({
+        type: 'external',
+        internalLink: {_ref: 'page-1', _type: 'reference'},
+      } as LinkValue),
+    ).toBe(
+      'Link type is URL but an internal document reference is set. Select Internal or clear the reference.',
+    )
+  })
+
+  it('flags internal type with URL but no internal reference', () => {
+    expect(
+      validateLinkTypeConsistency({
+        type: 'internal',
+        url: 'https://example.com',
+      } as LinkValue),
+    ).toBe('Link type is Internal but a URL is set. Select URL or clear the URL.')
+  })
+
+  it('ignores missing or empty values', () => {
+    expect(validateLinkTypeConsistency(undefined)).toBe(true)
+    expect(validateLinkTypeConsistency({type: 'internal'})).toBe(true)
+    expect(validateLinkTypeConsistency({type: 'external'})).toBe(true)
+  })
+})

--- a/src/helpers/validateLinkConsistency.ts
+++ b/src/helpers/validateLinkConsistency.ts
@@ -1,0 +1,35 @@
+import type {LinkValue} from '../types'
+
+type LinkFields = {
+  type?: string
+  internalLink?: {_ref?: string}
+  url?: string
+}
+
+function hasInternalReference(link: LinkFields): boolean {
+  const ref = link.internalLink?._ref
+  return typeof ref === 'string' && ref.length > 0
+}
+
+/**
+ * Validates that the link `type` matches populated link value fields.
+ */
+export function validateLinkTypeConsistency(link: LinkValue | undefined): true | string {
+  if (!link?.type) {
+    return true
+  }
+
+  const fields = link as LinkFields
+  const hasInternalRef = hasInternalReference(fields)
+  const hasUrl = typeof fields.url === 'string' && fields.url.length > 0
+
+  if (fields.type === 'external' && hasInternalRef && !hasUrl) {
+    return 'Link type is URL but an internal document reference is set. Select Internal or clear the reference.'
+  }
+
+  if (fields.type === 'internal' && hasUrl && !hasInternalRef) {
+    return 'Link type is Internal but a URL is set. Select URL or clear the URL.'
+  }
+
+  return true
+}

--- a/src/linkField.tsx
+++ b/src/linkField.tsx
@@ -4,6 +4,7 @@ import {CustomLinkInput} from './components/CustomLinkInput'
 import {LinkInput} from './components/LinkInput'
 import {LinkTypeInput} from './components/LinkTypeInput'
 import {isCustomLink} from './helpers/typeGuards'
+import {validateLinkTypeConsistency} from './helpers/validateLinkConsistency'
 import type {LinkFieldPluginOptions, LinkSchemaType, LinkValue} from './types'
 
 /**
@@ -68,6 +69,8 @@ export const linkField = definePlugin<LinkFieldPluginOptions | void>((opts) => {
     type: 'object',
     icon,
     preview,
+    validation: (Rule) =>
+      Rule.custom((value) => validateLinkTypeConsistency(value as LinkValue | undefined)),
     fieldsets: [
       {
         name: 'advanced',


### PR DESCRIPTION
## Summary

- Fixes [#39](https://github.com/winteragency/sanity-plugin-link-field/issues/39) where the link field could save `type: "external"` with a populated `internalLink` after picking an internal document
- Adds React `key` props on type/link `ObjectInputMember` slots to prevent stale input reuse when the active link field changes
- Clears inactive link value fields (`internalLink`, `url`, etc.) when the user explicitly switches link type via `PatchEvent`
- Adds object-level validation that flags type/data mismatches with a clear editor message

Builds on the name-based member resolution from [#40](https://github.com/winteragency/sanity-plugin-link-field/pull/40) (this branch includes those commits).

## Test plan

- [x] `npm test` (38 tests)
- [x] `npm run check:types`
- [x] `npm run lint`
- [x] Manual: pick internal document, refresh page — type stays `internal`
- [x] Manual: use inside `internationalizedArrayLink` wrapper
- [x] Manual: switch Internal → URL → Internal — stale `_ref` / `url` cleared

Fixes #39
Closes #25 