### PR TITLE
docs: add credits section to README

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,21 @@
+name: Contributors
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: akhilmhdh/contributors-readme-action@v2.3.11
+        with:
+          image_size: '70'
+          pr_title_on_protected: 'docs(readme): update contributor list'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ For each individual link field you add to your schema, you can set these options
 | enableText  | `false`  | Whether the link should include an optional field for setting the link text/label. If enabled, this will be available on the resulting link object under the `.text` property. |
 | textLabel  | `Text`  | The label for the text input field, if enabled using the `enableText` option. |
 
+## 🙌 Credits
+
+This plugin was originally built and open-sourced by [@marcusforsberg](https://github.com/marcusforsberg) and [Winter Agency](https://winteragency.se).
+
+Further development and improvements were contributed by [@frodeste](https://github.com/frodeste), generously sponsored by [ProsessPilotene](https://prosesspilotene.no/).
+
 ## 🔏 License
 
 [MIT](LICENSE) © [Winter Agency](https://winteragency.se)

--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ This plugin was originally built and open-sourced by [@marcusforsberg](https://g
 
 Further development and improvements were contributed by [@frodeste](https://github.com/frodeste), generously sponsored by [ProsessPilotene](https://prosesspilotene.no/).
 
+<!-- readme: marcusforsberg,frodeste -start -->
+<!-- readme: marcusforsberg,frodeste -end -->
+
+### Thanks to
+
+<!-- readme: contributors,marcusforsberg/-,frodeste/-,semantic-release-bot/- -start -->
+<!-- readme: contributors,marcusforsberg/-,frodeste/-,semantic-release-bot/- -end -->
+
 ## 🔏 License
 
 [MIT](LICENSE) © [Winter Agency](https://winteragency.se)


### PR DESCRIPTION
## Summary

Adds a Credits section to the README and automates an ongoing contributor list, so future contributors are acknowledged without manual updates.

Big thanks to @frodeste for the further development and improvements, generously sponsored by [ProsessPilotene](https://prosesspilotene.no/). This adds proper, lasting credit in the project's documentation.

## Changes

- Add a `## 🙌 Credits` section above the License, crediting [@marcusforsberg](https://github.com/marcusforsberg) and Winter Agency (original authors), and [@frodeste](https://github.com/frodeste) / ProsessPilotene (further development).
- Add a pinned avatar block for the two above, plus a `### Thanks to` section that automatically lists all other contributors.
- Add a `.github/workflows/contributors.yml` workflow (using [`akhilmhdh/contributors-readme-action`](https://github.com/akhilmhdh/contributors-readme-action)) that regenerates the list on every push to `main`.
- Exclude bots and already-credited maintainers from the auto list (`semantic-release-bot`, `@marcusforsberg`, `@frodeste`).

## Notes

- The contributor marker blocks are empty in this PR; the action populates them on the first run after merge. On a protected `main` it opens a follow-up PR titled `docs(readme): update contributor list`.