### PR TITLE
feat: add requireText option to require a link label

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ For each individual link field you add to your schema, you can set these options
 | Option | Default Value | Description |
 | ------------- | ------------- | ------------- |
 | enableText  | `false`  | Whether the link should include an optional field for setting the link text/label. If enabled, this will be available on the resulting link object under the `.text` property. |
-| requireText | `false` | Whether the text/label should be required when `enableText` is true. This only works as long as you do not add your own validation rules to the link field. See [Making a required link field](#3-making-a-required-link-field) for more details. |
+| requireText | `false` | Whether the text/label should be required when `enableText` is true. If you add field-level validation, ensure it includes `requiredLinkField` (passed directly to `rule.custom`) so the validation context is available. See [Making a required link field](#3-making-a-required-link-field) for more details. |
 | textLabel  | `Text`  | The label for the text input field, if enabled using the `enableText` option. |
 | enabledBuiltInLinkTypes | `undefined` | Built-in link types to show for this specific field. Overrides the plugin-level `enabledBuiltInLinkTypes`. |
 | linkableSchemaTypes | `undefined` | Allowed schema types for internal links on this specific field. Overrides plugin-level `linkableSchemaTypes`. |

--- a/README.md
+++ b/README.md
@@ -109,9 +109,14 @@ defineField({
   name: 'link',
   title: 'Link',
   type: 'link',
-  validation: (rule) => rule.custom((field) => requiredLinkField(field)),
+  validation: (rule) => rule.custom(requiredLinkField),
 })
 ```
+
+Pass `requiredLinkField` directly to `rule.custom` (rather than wrapping it) so it also receives the validation context. This lets it enforce the [`requireText`](#field-level) option in addition to requiring the link itself.
+
+> [!NOTE]
+> A field-level `validation` overrides the link type's own validation. `requiredLinkField` re-checks `requireText` for you, but if you were to write a **fully custom** `validation` that doesn't call `requiredLinkField`, it would not enforce `requireText`.
 
 ### 4. Rendering links on the frontend
 
@@ -357,7 +362,7 @@ For each individual link field you add to your schema, you can set these options
 | Option | Default Value | Description |
 | ------------- | ------------- | ------------- |
 | enableText  | `false`  | Whether the link should include an optional field for setting the link text/label. If enabled, this will be available on the resulting link object under the `.text` property. |
-| requireText | `false` | Whether the text/label should be required when `enableText` is true. |
+| requireText | `false` | Whether the text/label should be required when `enableText` is true. This only works as long as you do not add your own validation rules to the link field. See [Making a required link field](#3-making-a-required-link-field) for more details. |
 | textLabel  | `Text`  | The label for the text input field, if enabled using the `enableText` option. |
 | enabledBuiltInLinkTypes | `undefined` | Built-in link types to show for this specific field. Overrides the plugin-level `enabledBuiltInLinkTypes`. |
 | linkableSchemaTypes | `undefined` | Allowed schema types for internal links on this specific field. Overrides plugin-level `linkableSchemaTypes`. |

--- a/example/schemaTypes/demo.ts
+++ b/example/schemaTypes/demo.ts
@@ -17,8 +17,9 @@ export const demo = defineType({
       type: 'link',
       options: {
         enableText: true,
+        requireText: true,
       },
-      validation: (rule) => rule.custom((field) => requiredLinkField(field)),
+      validation: (rule) => rule.custom(requiredLinkField),
     }),
   ],
 })

--- a/src/helpers/requiredLinkField.test.ts
+++ b/src/helpers/requiredLinkField.test.ts
@@ -3,61 +3,54 @@ import {describe, expect, it} from 'vitest'
 import type {LinkValue} from '../types'
 import {requiredLinkField} from './requiredLinkField'
 
+const requireTextContext = {type: {options: {enableText: true, requireText: true}}}
+
 describe('requiredLinkField', () => {
   it('requires a link type', () => {
-    expect(requiredLinkField(undefined)).toBe('Link is required')
-    expect(requiredLinkField({} as LinkValue)).toBe('Link is required')
+    expect(requiredLinkField(undefined)).toEqual([{message: 'Link is required'}])
+    expect(requiredLinkField({} as LinkValue)).toEqual([{message: 'Link is required'}])
   })
 
   it('requires internalLink for internal links', () => {
-    expect(requiredLinkField({type: 'internal'} as LinkValue)).toEqual({
-      message: 'Link is required',
-      path: ['internalLink'],
-    })
+    expect(requiredLinkField({type: 'internal'} as LinkValue)).toEqual([
+      {message: 'Link is required', path: ['internalLink']},
+    ])
   })
 
   it('requires url for external links', () => {
-    expect(requiredLinkField({type: 'external'} as LinkValue)).toEqual({
-      message: 'URL is required',
-      path: ['url'],
-    })
+    expect(requiredLinkField({type: 'external'} as LinkValue)).toEqual([
+      {message: 'URL is required', path: ['url']},
+    ])
   })
 
   it('requires email for email links', () => {
-    expect(requiredLinkField({type: 'email'} as LinkValue)).toEqual({
-      message: 'E-mail is required',
-      path: ['email'],
-    })
+    expect(requiredLinkField({type: 'email'} as LinkValue)).toEqual([
+      {message: 'E-mail is required', path: ['email']},
+    ])
   })
 
   it('requires phone for phone links', () => {
-    expect(requiredLinkField({type: 'phone'} as LinkValue)).toEqual({
-      message: 'Phone number is required',
-      path: ['phone'],
-    })
+    expect(requiredLinkField({type: 'phone'} as LinkValue)).toEqual([
+      {message: 'Phone number is required', path: ['phone']},
+    ])
   })
 
   it('requires assetLink for asset links', () => {
-    expect(requiredLinkField({type: 'asset'} as LinkValue)).toEqual({
-      message: 'Asset is required',
-      path: ['assetLink'],
-    })
+    expect(requiredLinkField({type: 'asset'} as LinkValue)).toEqual([
+      {message: 'Asset is required', path: ['assetLink']},
+    ])
   })
 
   it('requires value for custom links', () => {
-    expect(requiredLinkField({type: 'archive'} as LinkValue)).toEqual({
-      message: 'Value is required',
-      path: ['value'],
-    })
+    expect(requiredLinkField({type: 'archive'} as LinkValue)).toEqual([
+      {message: 'Value is required', path: ['value']},
+    ])
   })
 
   it('passes when the active field is populated', () => {
-    expect(
-      requiredLinkField({
-        type: 'external',
-        url: 'https://example.com',
-      } as LinkValue),
-    ).toBe(true)
+    expect(requiredLinkField({type: 'external', url: 'https://example.com'} as LinkValue)).toBe(
+      true,
+    )
 
     expect(
       requiredLinkField({
@@ -65,5 +58,66 @@ describe('requiredLinkField', () => {
         internalLink: {_type: 'page', _ref: 'page-id'},
       } as LinkValue),
     ).toBe(true)
+  })
+
+  it('enforces requireText only when the field options require it', () => {
+    // No context → requireText is not enforced.
+    expect(requiredLinkField({type: 'external', url: 'https://example.com'} as LinkValue)).toBe(
+      true,
+    )
+
+    // Context requires text but the label is missing → flagged.
+    expect(
+      requiredLinkField(
+        {type: 'external', url: 'https://example.com'} as LinkValue,
+        requireTextContext,
+      ),
+    ).toEqual([{message: 'Link label is required', path: ['text']}])
+
+    // Label present → valid.
+    expect(
+      requiredLinkField(
+        {type: 'external', url: 'https://example.com', text: 'Example'} as LinkValue,
+        requireTextContext,
+      ),
+    ).toBe(true)
+  })
+
+  it('flags the link value and the text label at the same time', () => {
+    expect(requiredLinkField({type: 'internal'} as LinkValue, requireTextContext)).toEqual([
+      {message: 'Link is required', path: ['internalLink']},
+      {message: 'Link label is required', path: ['text']},
+    ])
+  })
+
+  it('does not require text when enableText is false', () => {
+    expect(
+      requiredLinkField({type: 'external', url: 'https://example.com'} as LinkValue, {
+        type: {options: {enableText: false, requireText: true}},
+      }),
+    ).toBe(true)
+  })
+
+  it('does not require text when requireText is false', () => {
+    expect(
+      requiredLinkField({type: 'external', url: 'https://example.com'} as LinkValue, {
+        type: {options: {enableText: true, requireText: false}},
+      }),
+    ).toBe(true)
+  })
+
+  it('treats a whitespace-only label as missing', () => {
+    expect(
+      requiredLinkField(
+        {type: 'external', url: 'https://example.com', text: '   '} as LinkValue,
+        requireTextContext,
+      ),
+    ).toEqual([{message: 'Link label is required', path: ['text']}])
+  })
+
+  it('ignores a context without type options', () => {
+    expect(requiredLinkField({type: 'external', url: 'https://example.com'} as LinkValue, {})).toBe(
+      true,
+    )
   })
 })

--- a/src/helpers/requiredLinkField.ts
+++ b/src/helpers/requiredLinkField.ts
@@ -1,6 +1,6 @@
-import type {CustomValidatorResult} from 'sanity'
+import type {CustomValidatorResult, ValidationError} from 'sanity'
 
-import type {LinkValue} from '../types'
+import type {LinkFieldOptions, LinkValue} from '../types'
 import {
   isAssetLink,
   isCustomLink,
@@ -15,50 +15,56 @@ import {
 
 /**
  * Helper to create a required link field.
+ *
+ * Pass it directly to `rule.custom` so it also receives the validation context:
+ * `validation: (rule) => rule.custom(requiredLinkField)`. With the context it
+ * additionally enforces the `requireText` option, which the plugin's type-level
+ * validation cannot guarantee once a field defines its own `validation`.
+ *
+ * Returns an array of errors so the link value and the text label can be
+ * flagged at the same time, or `true` when the field is valid.
  */
-export const requiredLinkField = (field: unknown): CustomValidatorResult => {
-  const link = field as LinkValue
+export const requiredLinkField = (
+  field: unknown,
+  context?: {type?: {options?: unknown}},
+): CustomValidatorResult => {
+  const link = field as LinkValue | undefined
   const hasValue = (value?: string) => Boolean(value?.trim())
+  const options = context?.type?.options as LinkFieldOptions | undefined
 
+  const errors: ValidationError[] = []
+
+  // Validate the link value itself. Only the active type's field is checked,
+  // so at most one link-value error applies.
   if (!link || !link.type) {
-    return 'Link is required'
+    errors.push({message: 'Link is required'})
+  } else if (isInternalLink(link) && !link.internalLink) {
+    errors.push({message: 'Link is required', path: ['internalLink']})
+  } else if (isExternalLink(link) && !hasValue(link.url)) {
+    errors.push({message: 'URL is required', path: ['url']})
+  } else if (isEmailLink(link) && !hasValue(link.email)) {
+    errors.push({message: 'E-mail is required', path: ['email']})
+  } else if (isPhoneLink(link) && !hasValue(link.phone)) {
+    errors.push({message: 'Phone number is required', path: ['phone']})
+  } else if (isAssetLink(link) && !link.assetLink?.asset) {
+    errors.push({message: 'Asset is required', path: ['assetLink']})
+  } else if (isSMSLink(link) && !hasValue(link.sms)) {
+    errors.push({message: 'Phone number is required', path: ['sms']})
+  } else if (isWhatsAppLink(link) && !hasValue(link.whatsapp)) {
+    errors.push({message: 'Phone number is required', path: ['whatsapp']})
+  } else if (isFaxLink(link) && !hasValue(link.fax)) {
+    errors.push({message: 'Fax number is required', path: ['fax']})
+  } else if (isCustomLink(link) && !hasValue(link.value)) {
+    errors.push({message: 'Value is required', path: ['value']})
   }
 
-  if (isInternalLink(link) && !link.internalLink) {
-    return {message: 'Link is required', path: ['internalLink']}
+  // Validate the text label independently so it can be flagged alongside a
+  // link-value error. When a field defines its own `validation` (e.g. this
+  // helper), it overrides the link type's validation, so the type-level
+  // requireText check never runs; reading the field options here covers that.
+  if (options?.enableText && options.requireText && !hasValue(link?.text)) {
+    errors.push({message: 'Link label is required', path: ['text']})
   }
 
-  if (isExternalLink(link) && !hasValue(link.url)) {
-    return {message: 'URL is required', path: ['url']}
-  }
-
-  if (isEmailLink(link) && !hasValue(link.email)) {
-    return {message: 'E-mail is required', path: ['email']}
-  }
-
-  if (isPhoneLink(link) && !hasValue(link.phone)) {
-    return {message: 'Phone number is required', path: ['phone']}
-  }
-
-  if (isAssetLink(link) && !link.assetLink?.asset) {
-    return {message: 'Asset is required', path: ['assetLink']}
-  }
-
-  if (isSMSLink(link) && !hasValue(link.sms)) {
-    return {message: 'Phone number is required', path: ['sms']}
-  }
-
-  if (isWhatsAppLink(link) && !hasValue(link.whatsapp)) {
-    return {message: 'Phone number is required', path: ['whatsapp']}
-  }
-
-  if (isFaxLink(link) && !hasValue(link.fax)) {
-    return {message: 'Fax number is required', path: ['fax']}
-  }
-
-  if (isCustomLink(link) && !hasValue(link.value)) {
-    return {message: 'Value is required', path: ['value']}
-  }
-
-  return true
+  return errors.length > 0 ? errors : true
 }


### PR DESCRIPTION
## Summary

Completes the `requireText` option so it actually enforces a required link label.

`requireText` was introduced in #35 (thanks @frodeste!) and enforced through the link type's object-level validation. That works until a field defines its own `validation`, which Sanity treats as a replacement for the type's validation. Since the documented way to require a link is exactly that (`rule.custom(requiredLinkField)`), `requireText` silently stopped applying in the most common case, and #12 was not actually resolved.

## What changed

- `requiredLinkField` now reads the field options from the validation context and enforces `requireText`.
- It returns an array of errors, so a missing link value and a missing label are flagged at the same time.
- The README and example schema pass `requiredLinkField` directly to `rule.custom` so the context flows through, with a note that a fully custom `validation` that doesn't call `requiredLinkField` won't enforce `requireText`.
- Tests cover the enforcement, the `enableText`/`requireText` guards, whitespace-only labels, and partial contexts.

## Release note framing

#35 has not been released yet, so this lands in the same **1.7.0** release. It is committed as a `feat` so the changelog announces the `requireText` option as a feature (which is how #35 intended to present it), rather than as a fix for an unreleased gap.

Closes #12
