### PR TITLE
feat: adopt @sanity/ui v4 subpath imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@eslint/js": "^9.39.4",
         "@sanity/pkg-utils": "^10.7.2",
         "@sanity/plugin-kit": "^6.0.0",
-        "@sanity/ui": "^3",
+        "@sanity/ui": "^4",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -52,7 +52,7 @@
         "npm": ">=11.17.0"
       },
       "peerDependencies": {
-        "@sanity/ui": "^3",
+        "@sanity/ui": "^4",
         "react": "^18 || ^19",
         "sanity": "^3 || ^4 || ^5 || ^6",
         "styled-components": "^5.2 || ^6"
@@ -3595,34 +3595,34 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3630,9 +3630,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "dev": true,
       "license": "MIT"
     },
@@ -7710,9 +7710,9 @@
       }
     },
     "node_modules/@sanity/color": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.6.tgz",
-      "integrity": "sha512-2TjYEvOftD0v7ukx3Csdh9QIu44P2z7NDJtlC3qITJRYV36J7R6Vfd3trVhFnN77/7CZrGjqngrtohv8VqO5nw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.8.tgz",
+      "integrity": "sha512-MBQ082q7GRvzSH7Xzx4ul1Kxm/AEKDgwTz5cd13oXIlenl3VAM0Un0QpeTjkC5IZTC7SHbnhwkgoVHTZDz9WKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7996,6 +7996,110 @@
         "@sanity/types": "*",
         "react": "^19.2"
       }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/@sanity/ui": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.5.3.tgz",
+      "integrity": "sha512-CedYCI42/qWp2IbYaFR/kCo+u2EjgWl0vd0FFTwiTvqpYzXeC2B9NQH/jmD77r3jGBwS0chtvUQeLxVZdezkUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@juggle/resize-observer": "^3.4.0",
+        "@sanity/color": "^3.0.8",
+        "@sanity/icons": "^5.2.1",
+        "csstype": "^3.2.3",
+        "motion": "^13.1.0",
+        "react-compiler-runtime": "1.0.0",
+        "react-is": "^19.2.8",
+        "react-refractor": "^4.0.0",
+        "use-effect-event": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || >=19.0.0-0",
+        "react-dom": "^18 || >=19.0.0-0",
+        "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/@sanity/ui/node_modules/@sanity/icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.2.1.tgz",
+      "integrity": "sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/framer-motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.0.tgz",
+      "integrity": "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^13.0.0",
+        "motion-utils": "^13.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-13.1.0.tgz",
+      "integrity": "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^13.1.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/motion-dom": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.0.0.tgz",
+      "integrity": "sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^13.0.0"
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/motion-utils": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
+      "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sanity/json-match": {
       "version": "1.0.5",
@@ -9157,31 +9261,106 @@
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.2.0.tgz",
-      "integrity": "sha512-bWi2zz8ixZcGHh1YXsgliHRaA9Vw11V5lkJN6SGZcuvbrwPFm6j71Cc3jL1l2MQ11I0HmUYmQ5E76+cT4SznYA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-4.0.4.tgz",
+      "integrity": "sha512-vFYoo7cmmYBHT9Gea40ZBoXpI/KmRnsuR//OxEK9lRRCOwPyn/vrEpht18GY9pIwxvip8UUNQG1RWv/fpqIAQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.6",
-        "@juggle/resize-observer": "^3.4.0",
-        "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.4",
-        "csstype": "^3.1.3",
-        "motion": "^12.23.24",
-        "react-compiler-runtime": "1.0.0",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@sanity/color": "^3.0.8",
+        "@sanity/icons": "^5.2.1",
+        "csstype": "^3.2.3",
+        "motion": "^13.1.0",
+        "react-is": "^19.2.8",
         "react-refractor": "^4.0.0",
         "use-effect-event": "^2.0.3"
       },
       "engines": {
+        "node": ">=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19.2",
+        "react-dom": "^19.2",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/@sanity/ui/node_modules/@sanity/icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.2.1.tgz",
+      "integrity": "sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "react": "^18 || >=19.0.0-0",
-        "react-dom": "^18 || >=19.0.0-0",
-        "react-is": "^18 || >=19.0.0-0",
-        "styled-components": "^5.2 || ^6"
+        "react": "^18 || ^19"
       }
+    },
+    "node_modules/@sanity/ui/node_modules/framer-motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.0.tgz",
+      "integrity": "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^13.0.0",
+        "motion-utils": "^13.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/ui/node_modules/motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-13.1.0.tgz",
+      "integrity": "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^13.1.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/ui/node_modules/motion-dom": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.0.0.tgz",
+      "integrity": "sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^13.0.0"
+      }
+    },
+    "node_modules/@sanity/ui/node_modules/motion-utils": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
+      "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sanity/util": {
       "version": "6.2.0",
@@ -23241,9 +23420,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -24422,6 +24601,69 @@
         "styled-components": "^6.1.15"
       }
     },
+    "node_modules/sanity/node_modules/@sanity/ui": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.5.3.tgz",
+      "integrity": "sha512-CedYCI42/qWp2IbYaFR/kCo+u2EjgWl0vd0FFTwiTvqpYzXeC2B9NQH/jmD77r3jGBwS0chtvUQeLxVZdezkUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@juggle/resize-observer": "^3.4.0",
+        "@sanity/color": "^3.0.8",
+        "@sanity/icons": "^5.2.1",
+        "csstype": "^3.2.3",
+        "motion": "^13.1.0",
+        "react-compiler-runtime": "1.0.0",
+        "react-is": "^19.2.8",
+        "react-refractor": "^4.0.0",
+        "use-effect-event": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || >=19.0.0-0",
+        "react-dom": "^18 || >=19.0.0-0",
+        "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/ui/node_modules/@sanity/icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.2.1.tgz",
+      "integrity": "sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/ui/node_modules/motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-13.1.0.tgz",
+      "integrity": "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^13.1.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sanity/node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -24432,6 +24674,47 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/sanity/node_modules/framer-motion": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.0.tgz",
+      "integrity": "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^13.0.0",
+        "motion-utils": "^13.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sanity/node_modules/motion-dom": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.0.0.tgz",
+      "integrity": "sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^13.0.0"
+      }
+    },
+    "node_modules/sanity/node_modules/motion-utils": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
+      "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sanity/node_modules/nanoid": {
       "version": "5.1.16",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@eslint/js": "^9.39.4",
     "@sanity/pkg-utils": "^10.7.2",
     "@sanity/plugin-kit": "^6.0.0",
-    "@sanity/ui": "^3",
+    "@sanity/ui": "^4",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
@@ -97,7 +97,7 @@
     "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "@sanity/ui": "^3",
+    "@sanity/ui": "^4",
     "react": "^18 || ^19",
     "sanity": "^3 || ^4 || ^5 || ^6",
     "styled-components": "^5.2 || ^6"

--- a/src/components/LinkTypeInput.tsx
+++ b/src/components/LinkTypeInput.tsx
@@ -1,5 +1,6 @@
 import {ChevronDownIcon} from '@sanity/icons'
-import {Button, Menu, MenuButton, MenuItem, Select} from '@sanity/ui'
+import {Button, Select} from '@sanity/ui'
+import {Menu, MenuButton, MenuItem} from '@sanity/ui/menu'
 import {LinkIcon} from 'lucide-react'
 import {memo, useContext, useMemo} from 'react'
 import type {StringInputProps} from 'sanity'


### PR DESCRIPTION
## What changed

`@sanity/ui` v4 moved heavy components out of the root entry point into dedicated subpaths. This updates the plugin to the new import structure:

- **`src/components/LinkTypeInput.tsx`** — import `Menu`, `MenuButton`, and `MenuItem` from `@sanity/ui/menu` instead of `@sanity/ui`. `Button` and `Select` remain root imports. (`CustomLinkInput` and `LinkInput` only use root-level components, so they were left unchanged.)
- **`package.json`** — bump `@sanity/ui` to `^4` in both `peerDependencies` and `devDependencies`.
- **`package-lock.json`** — regenerated for `@sanity/ui@4.0.4`.

## Why

The `@sanity/ui/menu` subpath only exists in v4; keeping the `Menu` family on the root entry breaks against v4. Aligning the imports and the peer range makes the plugin build and run correctly on modern Sanity Studio (v6 ships `@sanity/ui@4`).

## Reviewer notes

- ⚠️ **Breaking for v3 consumers:** the `@sanity/ui/menu` subpath does not exist in `@sanity/ui@3`, so this drops support for studios still on `@sanity/ui@3`. The peer range is now `^4`.
- Verified locally: `npm run build` (clean `dist/`), `npm run check:types`, and `npm test` (70/70 passing). Pre-commit hooks (prettier, types, lint) also pass.
- No version bump included — left for the release workflow / maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)